### PR TITLE
Allow external_linter to specify working directory and expand color palette

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
+          - "3.10"
+          - "3.11"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,25 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        include:
+          - python-version: "3.14"
+            experimental: true
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental == true }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - run: python -m pip install isort mypy
       - run: python -m pip install -e .
       - run: ./example-lint

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,16 +10,25 @@ on:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        include:
+          - python-version: "3.14"
+            experimental: true
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental == true }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - run: python -m pip install isort mypy
       - run: python -m pip install -e .
       - run: ./example-lint
@@ -29,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - run: python -m pip install isort mypy
       - run: python -m pip install -e .
       - run: ./example-lint

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,12 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
           - "3.10"
+          - "3.11"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: "3.11"
       - run: python -m pip install isort mypy
       - run: python -m pip install -e .
       - run: ./example-lint

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 zulint is a lightweight linting framework designed for complex
 applications using a mix of third-party linters and custom rules.
 
-This project requires Python 3.10 or newer.
+This project requires Python 3.10 or newer. Our CI tests run on Python 3.10–3.13 and the upcoming Python 3.14 pre-release.
 
 ## Why zulint
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ It has the following features:
 - Runs the linters in parallel, so you only have to wait for the
   slowest linter.  For Zulip, this is a ~4x performance improvement
   over running our third-party linters in series.
-- Produduces easy-to-read, clear terminal output, with each
-  independent linter given its own color.
+ - Produduces easy-to-read, clear terminal output, with each
+   independent linter given its own color from a palette including
+   orange, pink, and more.
 - Can check just modified files, or even as a `pre-commit` hook, only
   checking files that have changed (and only starting linters which
   check files that have changed).
@@ -85,6 +86,13 @@ optional arguments:
   --verbose, -v         Print verbose output where available
   --fix                 Automatically fix problems where supported
 ```
+
+### External linters in subdirectories
+
+When registering an external linter with `linter_config.external_linter`, you
+can now pass a `cwd` argument to run the linter in a different working
+directory.  This is helpful in monorepos where individual projects maintain
+their own configuration files.
 
 ### pre-commit hook mode
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 zulint is a lightweight linting framework designed for complex
 applications using a mix of third-party linters and custom rules.
 
+This project requires Python 3.10 or newer.
+
 ## Why zulint
 
 Modern full-stack web applications generally involve code written in

--- a/example-lint
+++ b/example-lint
@@ -30,9 +30,12 @@ def run() -> None:
 
     linter_config.external_linter('mypy', [sys.executable, 'tools/run-mypy'], ['py'], pass_targets=False,
                                   description="Static type checker for Python")
+    # `cwd` can be used to run the linter in a different directory so that it
+    # picks up configuration files from that location.
     linter_config.external_linter('isort', ['isort'], ['py'],
                                   check_arg=['--check-only', '--diff'],
-                                  description="Sorts Python import statements")
+                                  description="Sorts Python import statements",
+                                  cwd='.')
 
     @linter_config.lint
     def check_custom_rules() -> int:

--- a/example-lint
+++ b/example-lint
@@ -2,7 +2,6 @@
 
 import argparse
 import sys
-from typing import List, Tuple
 
 from zulint.command import LinterConfig, add_default_linter_arguments
 from zulint.custom_rules import RuleList
@@ -22,10 +21,10 @@ def run() -> None:
     # eg: file_types = ['py', 'html', 'css', 'js']
     file_types = ['py']
 
-    EXCLUDED_FILES = [
+    EXCLUDED_FILES: list[str] = [
         # No linters will be run on files in this list.
         # eg: 'path/to/file.py'
-    ]  # type: List[str]
+    ]
     by_lang = linter_config.list_files(file_types, exclude=EXCLUDED_FILES)
 
     linter_config.external_linter('mypy', [sys.executable, 'tools/run-mypy'], ['py'], pass_targets=False,
@@ -53,11 +52,11 @@ def run() -> None:
 
     @linter_config.lint
     def pyflakes() -> int:
-        suppress_patterns = [
+        suppress_patterns: list[tuple[str, str]] = [
             # Error patters in this list will be will not be reported by the linter.
             # syntax: ('File Path', 'Error message')
             # eg: ('path/to/file.py', 'imported but unused')
-        ]  # type: List[Tuple[str, str]]
+        ]
         failed = run_pyflakes(by_lang['py'], args, suppress_patterns)
         return 1 if failed else 0
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=long_description(),
     long_description_content_type='text/markdown',
     author_email='enquiries@adbwebdesigns.co.uk',
-    python_requires='>=3.5',
+    python_requires='>=3.10',
     url='https://github.com/adambirds/adamlint',
     packages=find_packages(exclude=('tests',)),
     package_data={
@@ -38,8 +38,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -4,11 +4,10 @@ import argparse
 import os
 import subprocess
 import sys
-from typing import List
 
 from zulint import lister
 
-EXCLUDE_FILES = []  # type: List[str]
+EXCLUDE_FILES: list[str] = []
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -149,7 +149,7 @@ class LinterConfig:
         such files, exits without doing anything.
 
         If target_langs is empty, just runs the linter unconditionally.
-        
+
         `cwd` specifies the working directory in which to execute the linter;
         if not provided, the current working directory is used.
         """

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -3,7 +3,7 @@ import logging
 import multiprocessing
 import sys
 import weakref
-from typing import Callable, Dict, List, Mapping, NoReturn, Sequence, Set, Tuple, Union
+from typing import Callable, Dict, List, Mapping, NoReturn, Optional, Sequence, Set, Tuple, Union
 
 from zulint import lister
 from zulint.linters import run_command
@@ -130,6 +130,7 @@ class LinterConfig:
         description: str = "External Linter",
         check_arg: Union[str, Sequence[str]] = [],
         suppress_line: Callable[[str], bool] = lambda line: False,
+        cwd: Optional[str] = None,
     ) -> None:
         """Registers an external linter program to be run as part of the
         linter.  This program will be passed the subset of files being
@@ -137,6 +138,9 @@ class LinterConfig:
         such files, exits without doing anything.
 
         If target_langs is empty, just runs the linter unconditionally.
+        
+        `cwd` specifies the working directory in which to execute the linter;
+        if not provided, the current working directory is used.
         """
         self.lint_descriptions[name] = description
         if fix_arg or check_arg:
@@ -161,7 +165,7 @@ class LinterConfig:
             if pass_targets:
                 full_command += targets
 
-            return run_command(name, color, full_command, suppress_line)
+            return run_command(name, color, full_command, suppress_line, cwd)
 
         self.lint_functions[name] = run_linter
 

--- a/zulint/command.py
+++ b/zulint/command.py
@@ -3,7 +3,18 @@ import logging
 import multiprocessing
 import sys
 import weakref
-from typing import Callable, Dict, List, Mapping, NoReturn, Optional, Sequence, Set, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    NoReturn,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 from zulint import lister
 from zulint.linters import run_command

--- a/zulint/linters.py
+++ b/zulint/linters.py
@@ -1,7 +1,7 @@
 import argparse
 import signal
 import subprocess
-from typing import Callable, Sequence, Tuple
+from typing import Callable, Optional, Sequence, Tuple
 
 from zulint.printer import colors, print_err
 
@@ -11,12 +11,14 @@ def run_command(
     color: str,
     command: Sequence[str],
     suppress_line: Callable[[str], bool] = lambda line: False,
+    cwd: Optional[str] = None,
 ) -> int:
     with subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         universal_newlines=True,
+        cwd=cwd,
     ) as p:
         assert p.stdout is not None
         for line in iter(p.stdout.readline, ""):

--- a/zulint/printer.py
+++ b/zulint/printer.py
@@ -1,15 +1,39 @@
 from itertools import cycle
 
-# Terminal Color codes for use in differentiatng linters
-BOLDRED = '\x1B[1;31m'
-GREEN = '\x1b[32m'
-YELLOW = '\x1b[33m'
-BLUE = '\x1b[34m'
-MAGENTA = '\x1b[35m'
-CYAN = '\x1b[36m'
-ENDC = '\033[0m'
+# Terminal Color codes for use in differentiating linters
+BOLDRED = "\x1B[1;31m"
+GREEN = "\x1b[32m"
+YELLOW = "\x1b[33m"
+BLUE = "\x1b[34m"
+MAGENTA = "\x1b[35m"
+CYAN = "\x1b[36m"
+WHITE = "\x1b[37m"
+BRIGHT_BLACK = "\x1b[90m"
+ORANGE = "\x1b[38;5;208m"
+PINK = "\x1b[38;5;205m"
+PURPLE = "\x1b[38;5;93m"
+LIME = "\x1b[38;5;118m"
+TEAL = "\x1b[38;5;30m"
+BROWN = "\x1b[38;5;94m"
+SKY_BLUE = "\x1b[38;5;117m"
+ENDC = "\033[0m"
 
-colors = cycle([GREEN, YELLOW, BLUE, MAGENTA, CYAN])
+colors = cycle([
+    GREEN,
+    YELLOW,
+    BLUE,
+    MAGENTA,
+    CYAN,
+    WHITE,
+    BRIGHT_BLACK,
+    ORANGE,
+    PINK,
+    PURPLE,
+    LIME,
+    TEAL,
+    BROWN,
+    SKY_BLUE,
+])
 
 def print_err(name: str, color: str, line: str) -> None:
     print('{color}{name}{pad}|{end} {red_color}{line!s}{end}'.format(


### PR DESCRIPTION
## Summary
- allow `external_linter` to run commands from a specific working directory
- document `cwd` usage and update example linter
- expand linter color palette with distinct colors while reserving red for errors

## Testing
- `python -m pytest`
- `./example-lint --list`
- `python -m py_compile example-lint zulint/command.py zulint/linters.py zulint/printer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2f2dade18833184fa724858729178